### PR TITLE
Release/0.0.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             gradle-caches-${{ runner.os }}-
       - name: Lint
-        run: ./gradlew lintAll
+        run: ./gradlew lint
       - name: Stop Gradle
         run: ./gradlew --stop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## Version 0.0.5
 
-_TBD_
+_2024-02-27_
 
 * Tag options per Retrofit service interface method.
 

--- a/dokka.gradle
+++ b/dokka.gradle
@@ -1,6 +1,7 @@
 apply plugin: "org.jetbrains.dokka"
 
 tasks.named("dokkaJavadoc") {
+    dependsOn(":halley-core:compileKotlin")
     dependsOn(":halley-plugin:pluginVersion")
     outputDirectory.set(file("$buildDir/javadoc"))
 

--- a/halley-ktor/build.gradle
+++ b/halley-ktor/build.gradle
@@ -16,8 +16,8 @@ compileKotlin {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs += [
-                '-opt-in=kotlinx.serialization.ExperimentalSerializationApi',
-                '-Xjvm-default=all'
+            '-opt-in=kotlinx.serialization.ExperimentalSerializationApi',
+            '-Xjvm-default=all'
         ]
     }
 }
@@ -32,8 +32,8 @@ dependencies {
     implementation libs.kotlin.core
     implementation libs.kotlinx.serialization
 
-    api libs.library.core
-//    api project(":halley-core")
+    // api libs.library.core
+    api project(":halley-core")
     implementation libs.ktor.core
     implementation libs.okhttp
 }

--- a/halley-retrofit/build.gradle
+++ b/halley-retrofit/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation libs.kotlin.core
     implementation libs.kotlinx.serialization
 
-    api libs.library.core
-//    api project(":halley-core")
+    // api libs.library.core
+    api project(":halley-core")
     implementation libs.okhttp
     implementation libs.retrofit
 }

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/cache/HalleyOptions.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/cache/HalleyOptions.kt
@@ -3,7 +3,6 @@ package com.infinum.halley.retrofit.cache
 import com.infinum.halley.core.serializers.link.models.templated.params.Arguments
 import com.infinum.halley.core.typealiases.HalleyKeyedMap
 import com.infinum.halley.core.typealiases.HalleyMap
-import com.infinum.halley.retrofit.converters.options.HalleyOptionsFactory
 
 /*
 HalleyOptions are constructed per call site (Retrofit service interface method) and stored in the cache.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath libs.tools.gradle
-        classpath libs.library.plugin
+        // classpath libs.library.plugin
     }
 }
 
@@ -15,7 +15,7 @@ plugins {
     alias libs.plugins.kotlin.android
 }
 
-apply plugin: "com.infinum.halley.plugin"
+// apply plugin: "com.infinum.halley.plugin"
 
 android {
     compileSdkVersion buildConfig.compileSdk


### PR DESCRIPTION
## :page_facing_up: Context
Released [v0.0.5](https://github.com/infinum/android-halley/releases/tag/v0.0.5) to [Maven Central](https://central.sonatype.com/namespace/com.infinum.halley) which includes the changes from [this PR](https://github.com/infinum/android-halley/pull/3).

## :pencil: Changes
- Made the `dokkaJavadoc` task depend on `:halley-core:compileKotlin` task.
- Added the release date in the `CHANGELOG.md`.
- Updated the CI workflow (the Lint step was failing because there is no `lintAll` task defined in the root `build.gradle` file. I set just the out of the box `lint` task to run on this step instead since all modules except the sample app are non-Android modules).