### PR TITLE
Update/decode maps support

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -1,7 +1,7 @@
 ext {
     def major = 0
     def minor = 0
-    def patch = 5
+    def patch = 6
 
     buildConfig = [
             "minSdk"    : 21,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-halley = "0.0.5"
+halley = "0.0.6"
 gradle = "7.4.2"
 kotlin = "1.8.10"
 serialization = "1.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-halley = "0.0.6"
+halley = "0.0.5"
 gradle = "7.4.2"
 kotlin = "1.8.10"
 serialization = "1.5.0"

--- a/halley-core/src/main/resources/META-INF/proguard/halley.pro
+++ b/halley-core/src/main/resources/META-INF/proguard/halley.pro
@@ -25,22 +25,4 @@
 # @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault
 
-# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
-# If you have any, uncomment and replace classes with those containing named companion objects.
-#-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
-#-if @kotlinx.serialization.Serializable class
-#com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
-#com.example.myapplication.HasNamedCompanion2
-#{
-#    static **$* *;
-#}
-#-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
-#    static <1>$$serializer INSTANCE;
-#}
-
-# This is generated automatically by the Android Gradle plugin.
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
--dontwarn org.joda.**
--dontwarn org.slf4j.**
+-keep class * extends com.infinum.halley.core.serializers.hal.models.HalResource { *; }

--- a/halley-core/src/main/resources/META-INF/proguard/halley.pro
+++ b/halley-core/src/main/resources/META-INF/proguard/halley.pro
@@ -25,4 +25,24 @@
 # @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault
 
+# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
+# If you have any, uncomment and replace classes with those containing named companion objects.
+#-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
+#-if @kotlinx.serialization.Serializable class
+#com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
+#com.example.myapplication.HasNamedCompanion2
+#{
+#    static **$* *;
+#}
+#-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
+#    static <1>$$serializer INSTANCE;
+#}
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+-dontwarn org.joda.**
+-dontwarn org.slf4j.**
+
 -keep class * extends com.infinum.halley.core.serializers.hal.models.HalResource { *; }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath libs.tools.gradle
-        // classpath libs.library.plugin
+        classpath libs.library.plugin
     }
 }
 
@@ -15,7 +15,7 @@ plugins {
     alias libs.plugins.kotlin.android
 }
 
-// apply plugin: "com.infinum.halley.plugin"
+apply plugin: "com.infinum.halley.plugin"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -70,13 +70,13 @@ android {
 }
 
 dependencies {
-//    implementation libs.library.retrofit
-//    implementation libs.library.ktor
-    implementation project(":halley-core")
-    implementation project(":halley-retrofit")
-    implementation project(":halley-ktor")
+    implementation libs.library.retrofit
+    implementation libs.library.ktor
+//    implementation project(":halley-core")
+//    implementation project(":halley-retrofit")
+//    implementation project(":halley-ktor")
 
-//    implementation libs.kotlin.core
+    implementation libs.kotlin.core
     implementation libs.bundles.androidx
     implementation libs.material
 

--- a/sample/src/main/kotlin/com/infinum/halley/sample/data/models/deserialization/ProfileResource.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/data/models/deserialization/ProfileResource.kt
@@ -31,7 +31,13 @@ data class ProfileResource(
     val user: UserResource? = null,
 
     @Transient
-    val age: Int = 40
+    val age: Int = 40,
+
+    @SerialName(value = "favouriteMeals")
+    val favouriteMeals: Map<String, String>? = null,
+
+    @SerialName(value = "categorizedAnimals")
+    val categorizedAnimals: Map<String, List<AnimalResource>>? = null
 
 ) : HalResource
 // CPD-ON

--- a/sample/src/main/resources/profile.json
+++ b/sample/src/main/resources/profile.json
@@ -14,6 +14,29 @@
   },
   "name": "Niko",
   "timezone": "Europe/Zagreb",
+  "favouriteMeals": {
+    "breakfast": "pancakes",
+    "lunch": "pasta",
+    "dinner": "lasagna"
+  },
+  "categorizedAnimals": {
+    "mammals": [
+      {
+        "name": "Lion",
+        "age": 3
+      },
+      {
+        "name": "Tiger",
+        "type": "2"
+      }
+    ],
+    "birds": [
+      {
+        "name": "Eagle",
+        "age": 5
+      }
+    ]
+  },
   "_links": {
     "self": {
       "href": "http://localhost:8080/api/Profile/self"


### PR DESCRIPTION
## :page_facing_up: Context
[Task](https://app.productive.io/1-infinum/projects/2590/tasks/task/8397198?board=85892&filter=MjQ1OTU5)

Added support for decoding properties of type `Map`.

## :pencil: Changes
- Added logic for decoding a property of type `Map` inside `PrimitiveDeserializerDelegate`. If the property is a `Map`, we extract the map’s key and value types and use them in the `MapSerializer`.
- Updated the models in the sample app and tested this on `mavenLocal`.
- Added a new proguard rule in Halley’s core module so that all classes which extend from `HalResource` are preserved. Otherwise, since we use reflection, issues appear after obfuscation on release build variants.

## 📷 Sample App Demo
Take a closer look at the bottom of the responses and you will see the deserialized `favouriteMeals` and `categorizedAnimals` `Map` properties:

https://github.com/infinum/android-halley/assets/83497391/3b11a0c3-3b74-4791-bd56-391c6e0553bb

