### PR TITLE
Add support for further customization of the call factory & switch the callback execution into another thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,26 +190,12 @@ val actual: HalModel = halley.decodeFromString(
 ```kotlin
 Retrofit.Builder()
     .addCallAdapterFactory(RxJava3CallAdapterFactory.create()) // Optional only if you use RxJava
-    // Halley for Retrofit provides an extension on KotlinX Serialization Json 
-    .addConverterFactory(Json.asHalleyConverterFactory(callFactory = callFactory))
+    // Halley for Retrofit provides an extension for setting Retrofit's call factory and adding Halley as a converter factory 
+    .withHalley(configuration = configuration, callFactory = callFactory)
     .addConverterFactory(ScalarsConverterFactory.create())
-    .callFactory(callFactory)
     .baseUrl(baseUrl)
     .build()
 ```
-
-> [!TIP]
-> Halley offers a `Call.Factory.asyncCallFactory` extension function to create a `Call.Factory` instance which that executes the callback in a new thread.
-> 
-> By default, OkHttp executes the callback code on the dispatcher thread, meaning that enqueuing another set of calls in the callback can
-> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to **switch the callback
-> execution into another thread from a non-fixed-sized thread pool**. By doing so, that thread (instead of the dispatcher thread) is blocked
-> while waiting for relationship calls to complete.
-> 
-> _Example of creating such `Call.Factory` instance:_
-> ```kotlin
-> val callFactory = OkHttpClient.Builder().build().asyncCallFactory()
-> ```
 
 ### Ktor
 

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ Retrofit.Builder()
 ```
 
 > [!TIP]
-> Halley offers a `Call.Factory` extension function to create a `Call.Factory` instance which that executes the callback in a new thread.
+> Halley offers a `Call.Factory.asyncCallFactory` extension function to create a `Call.Factory` instance which that executes the callback in a new thread.
 > 
 > By default, OkHttp executes the callback code on the dispatcher thread, meaning that enqueuing another set of calls in the callback can
-> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to switch the callback
-> execution into another thread from a non-fixed-sized thread pool. By doing so, that thread (instead of the dispatcher thread) is blocked
+> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to *switch the callback
+> execution into another thread from a non-fixed-sized thread pool*. By doing so, that thread (instead of the dispatcher thread) is blocked
 > while waiting for relationship calls to complete.
 > 
-> Example of creating such `Call.Factory` instance:
+> _Example of creating such `Call.Factory` instance:_
 > ```kotlin
 > val callFactory = OkHttpClient.Builder().build().asyncCallFactory()
 > ```

--- a/README.md
+++ b/README.md
@@ -191,12 +191,25 @@ val actual: HalModel = halley.decodeFromString(
 Retrofit.Builder()
     .addCallAdapterFactory(RxJava3CallAdapterFactory.create()) // Optional only if you use RxJava
     // Halley for Retrofit provides an extension on KotlinX Serialization Json 
-    .addConverterFactory(Json.asHalleyConverterFactory())
+    .addConverterFactory(Json.asHalleyConverterFactory(callFactory = callFactory))
     .addConverterFactory(ScalarsConverterFactory.create())
-    .client(httpClient)
+    .callFactory(callFactory)
     .baseUrl(baseUrl)
     .build()
 ```
+
+> [!TIP]
+> Halley offers a `Call.Factory` extension function to create a `Call.Factory` instance which that executes the callback in a new thread.
+> 
+> By default, OkHttp executes the callback code on the dispatcher thread, meaning that enqueuing another set of calls in the callback can
+> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to switch the callback
+> execution into another thread from a non-fixed-sized thread pool. By doing so, that thread (instead of the dispatcher thread) is blocked
+> while waiting for relationship calls to complete.
+> 
+> Example of creating such `Call.Factory` instance:
+> ```kotlin
+> val callFactory = OkHttpClient.Builder().build().asyncCallFactory()
+> ```
 
 ### Ktor
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ Retrofit.Builder()
 > Halley offers a `Call.Factory.asyncCallFactory` extension function to create a `Call.Factory` instance which that executes the callback in a new thread.
 > 
 > By default, OkHttp executes the callback code on the dispatcher thread, meaning that enqueuing another set of calls in the callback can
-> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to *switch the callback
-> execution into another thread from a non-fixed-sized thread pool*. By doing so, that thread (instead of the dispatcher thread) is blocked
+> exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible, use this factory to **switch the callback
+> execution into another thread from a non-fixed-sized thread pool**. By doing so, that thread (instead of the dispatcher thread) is blocked
 > while waiting for relationship calls to complete.
 > 
 > _Example of creating such `Call.Factory` instance:_

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
@@ -1,5 +1,6 @@
 package com.infinum.halley.core
 
+import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.core.loader.HttpClientCache
 import com.infinum.halley.core.serializers.hal.HalSerializer
 import com.infinum.halley.core.serializers.hal.models.HalResource
@@ -8,11 +9,12 @@ import java.lang.reflect.Type
 import kotlin.reflect.KClass
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
+import okhttp3.Call
 import okhttp3.OkHttpClient
 
 public class Halley(
     private val configuration: Configuration = Configuration(),
-    httpClient: OkHttpClient = OkHttpClient.Builder().build()
+    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
 ) {
     public companion object {
         public const val CONTENT_TYPE: String = "application"
@@ -56,7 +58,7 @@ public class Halley(
     }
 
     init {
-        HttpClientCache.save(httpClient)
+        HttpClientCache.save(callFactory)
     }
 
     public fun format(): Json = format

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
@@ -1,7 +1,7 @@
 package com.infinum.halley.core
 
 import com.infinum.halley.core.extensions.asyncCallFactory
-import com.infinum.halley.core.loader.HttpClientCache
+import com.infinum.halley.core.loader.CallFactoryCache
 import com.infinum.halley.core.serializers.hal.HalSerializer
 import com.infinum.halley.core.serializers.hal.models.HalResource
 import com.infinum.halley.core.serializers.link.models.templated.params.Arguments
@@ -58,7 +58,7 @@ public class Halley(
     }
 
     init {
-        HttpClientCache.save(callFactory)
+        CallFactoryCache.save(callFactory)
     }
 
     public fun format(): Json = format

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
@@ -1,6 +1,6 @@
 package com.infinum.halley.core
 
-import com.infinum.halley.core.extensions.asyncCallFactory
+import com.infinum.halley.core.extensions.halleyCallFactory
 import com.infinum.halley.core.loader.CallFactoryCache
 import com.infinum.halley.core.serializers.hal.HalSerializer
 import com.infinum.halley.core.serializers.hal.models.HalResource
@@ -58,7 +58,7 @@ public class Halley(
     }
 
     init {
-        CallFactoryCache.save(httpClient.asyncCallFactory())
+        CallFactoryCache.save(httpClient.halleyCallFactory())
     }
 
     public fun format(): Json = format

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/Halley.kt
@@ -14,7 +14,7 @@ import okhttp3.OkHttpClient
 
 public class Halley(
     private val configuration: Configuration = Configuration(),
-    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
+    httpClient: Call.Factory = OkHttpClient.Builder().build(),
 ) {
     public companion object {
         public const val CONTENT_TYPE: String = "application"
@@ -58,7 +58,7 @@ public class Halley(
     }
 
     init {
-        CallFactoryCache.save(callFactory)
+        CallFactoryCache.save(httpClient.asyncCallFactory())
     }
 
     public fun format(): Json = format

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/callfactories/AsyncCallFactory.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/callfactories/AsyncCallFactory.kt
@@ -1,0 +1,49 @@
+package com.infinum.halley.core.callfactories
+
+import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Request
+import okhttp3.Response
+
+internal class AsyncCallFactory(
+    private val delegate: Call.Factory,
+    private val executorService: ExecutorService,
+) : Call.Factory {
+    override fun newCall(request: Request): Call {
+        return AsyncCall(delegate.newCall(request), executorService)
+    }
+}
+
+internal class AsyncCall(
+    private val delegate: Call,
+    private val executorService: ExecutorService,
+) : Call by delegate {
+
+    private var task: Future<*>? = null
+
+    override fun cancel() {
+        delegate.cancel()
+        task?.cancel(true)
+    }
+
+    override fun clone(): Call = AsyncCall(delegate.clone(), executorService)
+
+    override fun enqueue(responseCallback: Callback) {
+        delegate.enqueue(AsyncCallback(responseCallback))
+    }
+
+    internal inner class AsyncCallback(
+        private val delegate: Callback,
+    ) : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            task = executorService.submit { delegate.onFailure(call, e) }
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+            task = executorService.submit { delegate.onResponse(call, response) }
+        }
+    }
+}

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
@@ -1,0 +1,25 @@
+package com.infinum.halley.core.extensions
+
+import com.infinum.halley.core.callfactories.AsyncCallFactory
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import okhttp3.Call
+import com.infinum.halley.core.loader.RelationshipLoader
+import com.infinum.halley.core.callfactories.AsyncCall.AsyncCallback
+
+/**
+ * Creates a new [Call.Factory] that executes the callback in a new thread.
+ *
+ * By default, OkHttp executes the callback code on the dispatcher thread,
+ * meaning that enqueuing another set of calls in the callback can exhaust the dispatcher (default maximum is 5).
+ * To free the dispatcher thread as soon as possible,
+ * [AsyncCallback] is used to switch the callback execution into another thread from a non-fixed-sized thread pool.
+ * By doing so, [RelationshipLoader] blocks that thread instead of the dispatcher thread
+ * while waiting for relationship calls to complete.
+ *
+ * @param executorService the executor service to use
+ * @return a new [Call.Factory] that executes the callback in a new thread
+ */
+public fun Call.Factory.asyncCallFactory(
+    executorService: ExecutorService = Executors.newCachedThreadPool(),
+): Call.Factory = AsyncCallFactory(this, executorService)

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
@@ -1,11 +1,11 @@
 package com.infinum.halley.core.extensions
 
+import com.infinum.halley.core.callfactories.AsyncCall.AsyncCallback
 import com.infinum.halley.core.callfactories.AsyncCallFactory
+import com.infinum.halley.core.loader.RelationshipLoader
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import okhttp3.Call
-import com.infinum.halley.core.loader.RelationshipLoader
-import com.infinum.halley.core.callfactories.AsyncCall.AsyncCallback
 
 /**
  * Creates a new [Call.Factory] that executes the callback in a new thread.

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/extensions/CallFactory.kt
@@ -20,6 +20,6 @@ import okhttp3.Call
  * @param executorService the executor service to use
  * @return a new [Call.Factory] that executes the callback in a new thread
  */
-public fun Call.Factory.asyncCallFactory(
+public fun Call.Factory.halleyCallFactory(
     executorService: ExecutorService = Executors.newCachedThreadPool(),
 ): Call.Factory = AsyncCallFactory(this, executorService)

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/CallFactoryCache.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/CallFactoryCache.kt
@@ -4,7 +4,7 @@ import com.infinum.halley.core.extensions.asyncCallFactory
 import okhttp3.Call
 import okhttp3.OkHttpClient
 
-internal object HttpClientCache {
+internal object CallFactoryCache {
 
     private var callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory()
 

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/CallFactoryCache.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/CallFactoryCache.kt
@@ -1,12 +1,12 @@
 package com.infinum.halley.core.loader
 
-import com.infinum.halley.core.extensions.asyncCallFactory
+import com.infinum.halley.core.extensions.halleyCallFactory
 import okhttp3.Call
 import okhttp3.OkHttpClient
 
 internal object CallFactoryCache {
 
-    private var callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory()
+    private var callFactory: Call.Factory = OkHttpClient.Builder().build().halleyCallFactory()
 
     fun save(callFactory: Call.Factory) {
         this.callFactory = callFactory

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
@@ -7,6 +7,7 @@ import com.infinum.halley.core.serializers.embedded.models.relationship.Relation
 import com.infinum.halley.core.serializers.link.models.templated.params.Arguments
 import com.infinum.halley.core.typealiases.HalleyMap
 import java.util.concurrent.CountDownLatch
+import okhttp3.Call
 import okhttp3.Request
 
 internal class HalRelationshipLoader : RelationshipLoader {
@@ -20,11 +21,16 @@ internal class HalRelationshipLoader : RelationshipLoader {
 
             val requestUrl = appendParameters(url, request.name, request.options)
 
-            CallFactoryCache.load().newCall(
+            val call = CallFactoryCache.load().newCall(
                 Request.Builder()
                     .url(requestUrl)
                     .build()
-            ).enqueue(callback)
+            )
+            try {
+                call.enqueue(callback)
+            } catch (ex: InterruptedException) {
+                call.cancel()
+            }
 
             countDownLatch.await()
         }
@@ -40,22 +46,30 @@ internal class HalRelationshipLoader : RelationshipLoader {
     ): List<RelationshipResponseHolder> {
         val countDownLatch = CountDownLatch(requests.validParametersSize)
         val callback = LoaderCallback(countDownLatch, result::add)
+        val calls = mutableListOf<Call>()
 
-        requests
-            .requests
-            .mapNotNull {
-                replaceTemplatePlaceholders(it)?.let { url ->
-                    val requestUrl = appendParameters(url, it.name, it.options)
+        try {
+            requests
+                .requests
+                .mapNotNull {
+                    replaceTemplatePlaceholders(it)?.let { url ->
+                        val requestUrl = appendParameters(url, it.name, it.options)
 
-                    Request.Builder()
-                        .url(requestUrl)
-                        .build()
+                        Request.Builder()
+                            .url(requestUrl)
+                            .build()
+                    }
                 }
-            }
-            .forEach { CallFactoryCache.load().newCall(it).enqueue(callback) }
+                .forEach {
+                    val newCall = CallFactoryCache.load().newCall(it)
+                    calls.add(newCall)
+                    newCall.enqueue(callback)
+                }
+        } catch (ex: InterruptedException) {
+            calls.forEach { it.cancel() }
+        }
 
         countDownLatch.await()
-
         return result.toList()
     }
 

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
@@ -28,8 +28,9 @@ internal class HalRelationshipLoader : RelationshipLoader {
             try {
                 call.enqueue(callback)
                 countDownLatch.await()
-            } catch (ex: InterruptedException) {
+            } catch (interruptedException: InterruptedException) {
                 call.cancel()
+                throw interruptedException
             }
         }
 
@@ -62,8 +63,9 @@ internal class HalRelationshipLoader : RelationshipLoader {
         try {
             calls.forEach { it.enqueue(callback) }
             countDownLatch.await()
-        } catch (interrupt: InterruptedException) {
+        } catch (interruptedException: InterruptedException) {
             calls.forEach { it.cancel() }
+            throw interruptedException
         }
 
         return result.toList()

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HalRelationshipLoader.kt
@@ -20,7 +20,7 @@ internal class HalRelationshipLoader : RelationshipLoader {
 
             val requestUrl = appendParameters(url, request.name, request.options)
 
-            HttpClientCache.load().newCall(
+            CallFactoryCache.load().newCall(
                 Request.Builder()
                     .url(requestUrl)
                     .build()
@@ -52,7 +52,7 @@ internal class HalRelationshipLoader : RelationshipLoader {
                         .build()
                 }
             }
-            .forEach { HttpClientCache.load().newCall(it).enqueue(callback) }
+            .forEach { CallFactoryCache.load().newCall(it).enqueue(callback) }
 
         countDownLatch.await()
 

--- a/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HttpClientCache.kt
+++ b/halley-core/src/main/kotlin/com/infinum/halley/core/loader/HttpClientCache.kt
@@ -1,14 +1,16 @@
 package com.infinum.halley.core.loader
 
+import com.infinum.halley.core.extensions.asyncCallFactory
+import okhttp3.Call
 import okhttp3.OkHttpClient
 
 internal object HttpClientCache {
 
-    private var httpClient: OkHttpClient = OkHttpClient.Builder().build()
+    private var callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory()
 
-    fun save(client: OkHttpClient) {
-        httpClient = client
+    fun save(callFactory: Call.Factory) {
+        this.callFactory = callFactory
     }
 
-    fun load(): OkHttpClient = httpClient
+    fun load(): Call.Factory = callFactory
 }

--- a/halley-ktor/src/main/java/com/infinum/halley/ktor/extensions/Configuration.kt
+++ b/halley-ktor/src/main/java/com/infinum/halley/ktor/extensions/Configuration.kt
@@ -1,5 +1,4 @@
 import com.infinum.halley.core.Halley
-import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.ktor.HalleySerializationConverter
 import io.ktor.http.ContentType
 import io.ktor.serialization.Configuration
@@ -20,7 +19,7 @@ import okhttp3.OkHttpClient
  *          prettyPrint = true,
  *          prettyPrintIndent = "  ",
  *          explicitNulls = false,
- *          callFactory = callFactory,
+ *          httpClient = httpClient,
  *      )
  *  }
  * ```
@@ -40,7 +39,7 @@ public fun Configuration.defaultConfiguration(
     allowSpecialFloatingPointValues: Boolean =
         Json.Default.configuration.allowSpecialFloatingPointValues,
     useAlternativeNames: Boolean = Json.Default.configuration.useAlternativeNames,
-    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
+    httpClient: Call.Factory = OkHttpClient.Builder().build(),
 ) {
     register(
         ContentType.HAL,
@@ -60,7 +59,7 @@ public fun Configuration.defaultConfiguration(
                     allowSpecialFloatingPointValues = allowSpecialFloatingPointValues,
                     useAlternativeNames = useAlternativeNames,
                 ),
-                callFactory = callFactory,
+                httpClient = httpClient,
             )
         )
     )

--- a/halley-ktor/src/main/java/com/infinum/halley/ktor/extensions/Configuration.kt
+++ b/halley-ktor/src/main/java/com/infinum/halley/ktor/extensions/Configuration.kt
@@ -1,15 +1,17 @@
 import com.infinum.halley.core.Halley
+import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.ktor.HalleySerializationConverter
 import io.ktor.http.ContentType
 import io.ktor.serialization.Configuration
 import kotlinx.serialization.json.Json
+import okhttp3.Call
 import okhttp3.OkHttpClient
 
 /**
  * Registers the `application/vnd.hal+json` content type to the [HalleyNegotiation] plugin.
  *
  * The example below shows how to register the Halley serializer with
- * customized configuration settings and some HTTP client instance:
+ * customized configuration settings and some HTTP client call factory instance:
  * ```kotlin
  *  install(HalleyPlugin) {
  *      defaultConfiguration(
@@ -18,7 +20,7 @@ import okhttp3.OkHttpClient
  *          prettyPrint = true,
  *          prettyPrintIndent = "  ",
  *          explicitNulls = false,
- *          httpClient = httpClient
+ *          callFactory = callFactory,
  *      )
  *  }
  * ```
@@ -38,7 +40,7 @@ public fun Configuration.defaultConfiguration(
     allowSpecialFloatingPointValues: Boolean =
         Json.Default.configuration.allowSpecialFloatingPointValues,
     useAlternativeNames: Boolean = Json.Default.configuration.useAlternativeNames,
-    httpClient: OkHttpClient = OkHttpClient.Builder().build()
+    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
 ) {
     register(
         ContentType.HAL,
@@ -58,7 +60,7 @@ public fun Configuration.defaultConfiguration(
                     allowSpecialFloatingPointValues = allowSpecialFloatingPointValues,
                     useAlternativeNames = useAlternativeNames,
                 ),
-                httpClient = httpClient
+                callFactory = callFactory,
             )
         )
     )

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/converters/HalleyConverterFactory.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/converters/HalleyConverterFactory.kt
@@ -4,7 +4,7 @@ import com.infinum.halley.core.Halley
 import com.infinum.halley.core.serializers.hal.models.HalResource
 import com.infinum.halley.retrofit.converters.options.HalleyOptionsFactory
 import java.lang.reflect.Type
-import okhttp3.OkHttpClient
+import okhttp3.Call
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Converter
@@ -12,10 +12,10 @@ import retrofit2.Retrofit
 
 internal class HalleyConverterFactory(
     configuration: Halley.Configuration,
-    httpClient: OkHttpClient
+    callFactory: Call.Factory,
 ) : Converter.Factory() {
 
-    private val halley = Halley(configuration, httpClient)
+    private val halley = Halley(configuration, callFactory)
 
     @Suppress("RedundantNullableReturnType") // Retaining interface contract.
     override fun responseBodyConverter(

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
@@ -1,28 +1,30 @@
 package com.infinum.halley.retrofit.extensions
 
 import com.infinum.halley.core.Halley
+import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.retrofit.converters.HalleyConverterFactory
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.json.Json
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import retrofit2.Converter
 
 @JvmName("create")
 public fun BinaryFormat.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),
-    httpClient: OkHttpClient = OkHttpClient.Builder().build()
+    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
 ): Converter.Factory =
     HalleyConverterFactory(
         configuration = configuration,
-        httpClient = httpClient
+        callFactory = callFactory
     )
 
 @JvmName("create")
 public fun Json.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),
-    httpClient: OkHttpClient = OkHttpClient.Builder().build()
+    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
 ): Converter.Factory =
     HalleyConverterFactory(
         configuration = configuration,
-        httpClient = httpClient
+        callFactory = callFactory
     )

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
@@ -1,7 +1,6 @@
 package com.infinum.halley.retrofit.extensions
 
 import com.infinum.halley.core.Halley
-import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.retrofit.converters.HalleyConverterFactory
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.json.Json
@@ -12,19 +11,19 @@ import retrofit2.Converter
 @JvmName("create")
 public fun BinaryFormat.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),
-    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
+    httpClient: Call.Factory = OkHttpClient.Builder().build(),
 ): Converter.Factory =
     HalleyConverterFactory(
         configuration = configuration,
-        callFactory = callFactory
+        callFactory = httpClient
     )
 
 @JvmName("create")
 public fun Json.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),
-    callFactory: Call.Factory = OkHttpClient.Builder().build().asyncCallFactory(),
+    httpClient: Call.Factory = OkHttpClient.Builder().build(),
 ): Converter.Factory =
     HalleyConverterFactory(
         configuration = configuration,
-        callFactory = callFactory
+        callFactory = httpClient
     )

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Json.kt
@@ -8,6 +8,10 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import retrofit2.Converter
 
+@Deprecated(
+    message = "Use Retrofit.Builder.withHalley(configuration, callFactory) instead.",
+    replaceWith = ReplaceWith("Retrofit.Builder.withHalley(configuration, httpClient)"),
+)
 @JvmName("create")
 public fun BinaryFormat.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),
@@ -18,6 +22,10 @@ public fun BinaryFormat.asHalleyConverterFactory(
         callFactory = httpClient
     )
 
+@Deprecated(
+    message = "Use Retrofit.Builder.withHalley(configuration, callFactory) instead.",
+    replaceWith = ReplaceWith("Retrofit.Builder.withHalley(configuration, callFactory)"),
+)
 @JvmName("create")
 public fun Json.asHalleyConverterFactory(
     configuration: Halley.Configuration = Halley.Configuration(),

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
@@ -1,0 +1,14 @@
+package com.infinum.halley.retrofit.extensions
+
+import com.infinum.halley.core.Halley
+import com.infinum.halley.core.extensions.asyncCallFactory
+import com.infinum.halley.retrofit.converters.HalleyConverterFactory
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+public fun Retrofit.Builder.withHalley(
+    configuration: Halley.Configuration = Halley.Configuration(),
+    callFactory: Call.Factory = OkHttpClient.Builder().build(),
+): Retrofit.Builder = this.callFactory(callFactory.asyncCallFactory())
+    .addConverterFactory(HalleyConverterFactory(configuration, callFactory))

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
@@ -1,7 +1,7 @@
 package com.infinum.halley.retrofit.extensions
 
 import com.infinum.halley.core.Halley
-import com.infinum.halley.core.extensions.asyncCallFactory
+import com.infinum.halley.core.extensions.halleyCallFactory
 import com.infinum.halley.retrofit.converters.HalleyConverterFactory
 import okhttp3.Call
 import okhttp3.OkHttpClient
@@ -18,5 +18,5 @@ import retrofit2.Retrofit
 public fun Retrofit.Builder.withHalley(
     configuration: Halley.Configuration = Halley.Configuration(),
     callFactory: Call.Factory = OkHttpClient.Builder().build(),
-): Retrofit.Builder = this.callFactory(callFactory.asyncCallFactory())
+): Retrofit.Builder = this.callFactory(callFactory.halleyCallFactory())
     .addConverterFactory(HalleyConverterFactory(configuration, callFactory))

--- a/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
+++ b/halley-retrofit/src/main/kotlin/com/infinum/halley/retrofit/extensions/Retrofit.kt
@@ -7,6 +7,14 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 
+/**
+ * Creates a new [Retrofit.Builder] which sets Retrofit's call factory and adds Halley as a converter factory.
+ *
+ * @param configuration Halley configuration.
+ * @param callFactory The call factory to be used.
+ * @return A new [Retrofit.Builder] with configured [callFactory]
+ * and [HalleyConverterFactory] added as a converter factory with appropriate [configuration] and [callFactory].
+ */
 public fun Retrofit.Builder.withHalley(
     configuration: Halley.Configuration = Halley.Configuration(),
     callFactory: Call.Factory = OkHttpClient.Builder().build(),

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,16 +6,17 @@ buildscript {
     }
     dependencies {
         classpath libs.tools.gradle
-        classpath libs.library.plugin
+        // classpath libs.library.plugin
     }
 }
 
 plugins {
     alias libs.plugins.android.application
     alias libs.plugins.kotlin.android
+    id "org.jetbrains.kotlin.plugin.serialization"
 }
 
-apply plugin: "com.infinum.halley.plugin"
+// apply plugin: "com.infinum.halley.plugin"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -70,11 +71,11 @@ android {
 }
 
 dependencies {
-    implementation libs.library.retrofit
-    implementation libs.library.ktor
-//    implementation project(":halley-core")
-//    implementation project(":halley-retrofit")
-//    implementation project(":halley-ktor")
+//    implementation libs.library.retrofit
+//    implementation libs.library.ktor
+    implementation project(":halley-core")
+    implementation project(":halley-retrofit")
+    implementation project(":halley-ktor")
 
     implementation libs.kotlin.core
     implementation libs.bundles.androidx

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleClient.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleClient.kt
@@ -8,15 +8,15 @@ import com.infinum.halley.sample.mock.client.services.SampleRxService
 import com.infinum.halley.sample.mock.client.services.SampleService
 import java.util.UUID
 import kotlinx.serialization.json.Json
+import okhttp3.Call
 import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 
 class SampleClient(
     private val baseUrl: HttpUrl,
-    private val httpClient: OkHttpClient
+    private val callFactory: Call.Factory,
 ) {
 
     init {
@@ -46,11 +46,11 @@ class SampleClient(
                     prettyPrint = true,
                     prettyPrintIndent = "  "
                 ),
-                httpClient = httpClient
+                callFactory = callFactory,
             )
         )
         .addConverterFactory(ScalarsConverterFactory.create())
-        .client(httpClient)
+        .callFactory(callFactory)
         .baseUrl(baseUrl)
         .build()
 }

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleClient.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleClient.kt
@@ -2,12 +2,11 @@ package com.infinum.halley.sample.mock.client
 
 import com.infinum.halley.core.Halley
 import com.infinum.halley.retrofit.cache.halleyCommonOptions
-import com.infinum.halley.retrofit.extensions.asHalleyConverterFactory
+import com.infinum.halley.retrofit.extensions.withHalley
 import com.infinum.halley.sample.mock.client.services.SampleCoroutinesService
 import com.infinum.halley.sample.mock.client.services.SampleRxService
 import com.infinum.halley.sample.mock.client.services.SampleService
 import java.util.UUID
-import kotlinx.serialization.json.Json
 import okhttp3.Call
 import okhttp3.HttpUrl
 import retrofit2.Retrofit
@@ -39,18 +38,15 @@ class SampleClient(
     val serviceRx: SampleRxService by lazy { retrofit().create(SampleRxService::class.java) }
 
     private fun retrofit(): Retrofit = Retrofit.Builder()
-        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
-        .addConverterFactory(
-            Json.asHalleyConverterFactory(
-                configuration = Halley.Configuration(
-                    prettyPrint = true,
-                    prettyPrintIndent = "  "
-                ),
-                callFactory = callFactory,
-            )
+        .withHalley(
+            configuration = Halley.Configuration(
+                prettyPrint = true,
+                prettyPrintIndent = "  "
+            ),
+            callFactory = callFactory,
         )
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
         .addConverterFactory(ScalarsConverterFactory.create())
-        .callFactory(callFactory)
         .baseUrl(baseUrl)
         .build()
 }

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleKtor.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleKtor.kt
@@ -15,10 +15,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.URLProtocol
 import io.ktor.http.contentType
 import io.ktor.http.path
-import okhttp3.OkHttpClient
+import okhttp3.Call
 
 class SampleKtor(
-    private val httpClient: OkHttpClient
+    private val callFactory: Call.Factory,
 ) {
 
     companion object {
@@ -55,7 +55,7 @@ class SampleKtor(
                 prettyPrint = true,
                 prettyPrintIndent = "  ",
                 explicitNulls = false,
-                httpClient = httpClient
+                callFactory = callFactory,
             )
         }
     }

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleKtor.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/client/SampleKtor.kt
@@ -55,7 +55,7 @@ class SampleKtor(
                 prettyPrint = true,
                 prettyPrintIndent = "  ",
                 explicitNulls = false,
-                callFactory = callFactory,
+                httpClient = callFactory,
             )
         }
     }

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/server/SampleWebServer.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/server/SampleWebServer.kt
@@ -1,8 +1,10 @@
 package com.infinum.halley.sample.mock.server
 
+import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.sample.mock.client.SampleClient
 import com.infinum.halley.sample.mock.client.SampleKtor
 import kotlin.concurrent.thread
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockWebServer
@@ -17,13 +19,13 @@ class SampleWebServer {
     private var client: SampleClient? = null
     private var ktor: SampleKtor? = null
 
-    private val okhttp: OkHttpClient =
+    private val callFactory: Call.Factory =
         OkHttpClient.Builder()
             .addInterceptor(
                 HttpLoggingInterceptor()
                     .apply { level = HttpLoggingInterceptor.Level.BODY }
             )
-            .build()
+            .build().asyncCallFactory()
 
     fun start() {
         thread {
@@ -33,8 +35,8 @@ class SampleWebServer {
                 dispatcher = SampleDispatcher()
             }
             mockWebServer?.start(PORT)
-            client = SampleClient(mockWebServer?.url("/api/")!!, okhttp)
-            ktor = SampleKtor(okhttp)
+            client = SampleClient(mockWebServer?.url("/api/")!!, callFactory)
+            ktor = SampleKtor(callFactory)
         }
     }
 

--- a/sample/src/main/kotlin/com/infinum/halley/sample/mock/server/SampleWebServer.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/mock/server/SampleWebServer.kt
@@ -1,6 +1,5 @@
 package com.infinum.halley.sample.mock.server
 
-import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.sample.mock.client.SampleClient
 import com.infinum.halley.sample.mock.client.SampleKtor
 import kotlin.concurrent.thread
@@ -19,13 +18,12 @@ class SampleWebServer {
     private var client: SampleClient? = null
     private var ktor: SampleKtor? = null
 
-    private val callFactory: Call.Factory =
-        OkHttpClient.Builder()
-            .addInterceptor(
-                HttpLoggingInterceptor()
-                    .apply { level = HttpLoggingInterceptor.Level.BODY }
-            )
-            .build().asyncCallFactory()
+    private val callFactory: Call.Factory = OkHttpClient.Builder()
+        .addInterceptor(
+            HttpLoggingInterceptor()
+                .apply { level = HttpLoggingInterceptor.Level.BODY }
+        )
+        .build()
 
     fun start() {
         thread {

--- a/sample/src/main/kotlin/com/infinum/halley/sample/ui/MainActivity.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/ui/MainActivity.kt
@@ -4,7 +4,6 @@ package com.infinum.halley.sample.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.infinum.halley.core.Halley
-import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.core.serializers.link.models.Link
 import com.infinum.halley.core.serializers.link.models.templated.params.Arguments
 import com.infinum.halley.databinding.ActivityMainBinding
@@ -118,14 +117,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            callFactory = OkHttpClient.Builder()
+            httpClient = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build().asyncCallFactory()
+                .build()
         )
 
         val result: String = halley.encodeToString(
@@ -206,14 +205,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            callFactory = OkHttpClient.Builder()
+            httpClient = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build().asyncCallFactory()
+                .build()
         )
 
         val input = AssetLoader.loadFile("profile.json")
@@ -231,14 +230,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            callFactory = OkHttpClient.Builder()
+            httpClient = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build().asyncCallFactory()
+                .build()
         )
 
         val input = AssetLoader.loadFile("profile.json")

--- a/sample/src/main/kotlin/com/infinum/halley/sample/ui/MainActivity.kt
+++ b/sample/src/main/kotlin/com/infinum/halley/sample/ui/MainActivity.kt
@@ -4,6 +4,7 @@ package com.infinum.halley.sample.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.infinum.halley.core.Halley
+import com.infinum.halley.core.extensions.asyncCallFactory
 import com.infinum.halley.core.serializers.link.models.Link
 import com.infinum.halley.core.serializers.link.models.templated.params.Arguments
 import com.infinum.halley.databinding.ActivityMainBinding
@@ -117,14 +118,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            httpClient = OkHttpClient.Builder()
+            callFactory = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build()
+                .build().asyncCallFactory()
         )
 
         val result: String = halley.encodeToString(
@@ -205,14 +206,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            httpClient = OkHttpClient.Builder()
+            callFactory = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build()
+                .build().asyncCallFactory()
         )
 
         val input = AssetLoader.loadFile("profile.json")
@@ -230,14 +231,14 @@ class MainActivity : AppCompatActivity() {
                 prettyPrint = true,
                 prettyPrintIndent = "  "
             ),
-            httpClient = OkHttpClient.Builder()
+            callFactory = OkHttpClient.Builder()
                 .addInterceptor(
                     HttpLoggingInterceptor()
                         .apply {
                             level = HttpLoggingInterceptor.Level.BODY
                         }
                 )
-                .build()
+                .build().asyncCallFactory()
         )
 
         val input = AssetLoader.loadFile("profile.json")

--- a/sample/src/main/resources/profile.json
+++ b/sample/src/main/resources/profile.json
@@ -27,7 +27,7 @@
       },
       {
         "name": "Tiger",
-        "type": "2"
+        "age": 2
       }
     ],
     "birds": [


### PR DESCRIPTION
## Summary

- Added support for passing a `Call.Factory` which will be used by Halley to execute the requests (increasing the flexibility in configuring the `Call.Factory` instead of limiting it to an instance of `OkHttpClient`).
- Added an `AsyncCallFactory` wrapper for the call factory - the end goal is to avoid dispatcher exhaustion by switching the callback execution into another thread and ensure proper cancellation management.
- Exposed a `Retrofit.Builder.withHalley(configuration, call factory)` extension function in `:halley-retrofit` for easier Halley integration which should also ensure Retrofit’s call factory and the call factory Halley will use are correctly configured. Lib clients are encouraged to use this method when using Halley with Retrofit to avoid potential misconfiguration issues, therefore, I’ve marked some methods as deprecated which we will remove in some future release.

Huge shout to @antunflas for suggesting the idea of how dispatcher exhaustion can be avoided and helping me add support for this. 🙌 

## Changes

- Added `AsyncCallFactory` which executes the callback in a new thread. By default, OkHttp executes the callback code on the dispatcher thread, meaning that enqueuing another set of calls in the callback can exhaust the dispatcher (default maximum is 5). To free the dispatcher thread as soon as possible,  `AsyncCallback` is used to switch the callback execution into another thread from a non-fixed-sized thread pool. By doing so, `RelationshipLoader` blocks that thread instead of the dispatcher thread while waiting for relationship calls to complete.
- Added `Retrofit.Builder.withHalley(configuration, callFactory)` extension function in `:halley-retrofit`. It is important that Retrofit uses a call factory instance wrapped with `AsyncCallFactory` when making the initial call and after receiving the response, Halley should make any additionally required requests using the same call factory which is also appropriately wrapped with `AsyncCallFactory`. This extension function ensures a properly wrapped call factory is set to Retrofit and Halley is added as a converter factory.
- Updated all the places where `OkHttpClient` was requested with `Call.Factory` to allow more flexibility in customizing the call factory.
- Adjusted the sample app to the new changes. I’ve run the app and I didn’t notice any issues. Please double check the changes in the Ktor module since I’m not that familiar with Ktor in general.
- Updated the `README.md`.

### Type

- [X] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

> [!WARNING]
> There are no breaking changes for now, the compatibility is kept. However, lib clients are strongly encouraged to switch to using `Retrofit.Builder.withHalley(configuration, callFactory)` extension function instead of `Json.asHalleyConverterFactory(configuration, httpClient)` and `BinaryFormat.asHalleyConverterFactory(configuration, httpClient)` to avoid dispatcher exhaustion and ensure the call cancellation is handled correctly. These methods will be removed in future releases, so they have been marked as deprecated.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have tested my changes, including edge cases.
- [X] I have added necessary tests for the changes introduced (if applicable).
- [X] I have updated the documentation to reflect my changes (if applicable).